### PR TITLE
feat: You can now specify what validation library to use alongside `sveltekit-superforms`

### DIFF
--- a/.changeset/forty-timers-call.md
+++ b/.changeset/forty-timers-call.md
@@ -1,0 +1,5 @@
+---
+'@iedan/create': minor
+---
+
+feat: Can now choose what validation library you would like to use alongside SvelteKit superforms

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ npx @iedan/create
 ## Templates
 
 ### SvelteKit
+
 A starter project for **SvelteKit**.
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@iedan/create",
-	"version": "1.0.23",
+	"version": "1.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@iedan/create",
-			"version": "1.0.23",
+			"version": "1.1.0",
 			"license": "ISC",
 			"dependencies": {
 				"chalk": "^5.3.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1141,13 +1141,43 @@ const main = async () => {
 							name: 'sveltekit-superforms',
 							select: {
 								run: async ({ dir }) => {
-									await addDependencies(
-										dir,
-										packages['sveltekit-superforms'],
-										packages['zod']
-									);
+									await addDependencies(dir, packages['sveltekit-superforms']);
+
+									return [
+										{
+											kind: 'select',
+											message:
+												'What validation library would you like to use?',
+											initialValue: 'Zod',
+											options: [
+												{ name: 'Arktype', npmName: 'arktype' },
+												{ name: 'Joi', npmName: 'joi' },
+												{
+													name: 'JSON Schema',
+													npmName: '@exodus/schemasafe',
+												},
+												{ name: 'Superstruct', npmName: 'superstruct' },
+												{ name: 'TypeBox', npmName: '@sinclair/typebox' },
+												{ name: 'Valibot', npmName: 'valibot' },
+												{ name: 'VineJS', npmName: '@vinejs/vine' },
+												{ name: 'Yup', npmName: 'yup' },
+												{ name: 'Zod', npmName: 'zod' },
+											].map((pack) => ({
+												name: pack.name,
+												hint: pack.npmName,
+												select: {
+													run: async ({ dir }) => {
+														await addDependencies(
+															dir,
+															packages[pack.npmName]
+														);
+													},
+												},
+											})),
+										},
+									];
 								},
-								startMessage: 'Installing zod, and sveltekit-superforms',
+								startMessage: 'Installing sveltekit-superforms',
 								endMessage: 'Installed sveltekit-superforms',
 							},
 						},

--- a/src/packages.ts
+++ b/src/packages.ts
@@ -3,6 +3,46 @@ type Package = { name: string; version: string; scope: 'dev' | 'regular' };
 // Packages are kept here so that keeping track of versioning is easier
 
 export const packages: Record<string, Package> = {
+	arktype: {
+		name: 'arktype',
+		scope: 'regular',
+		version: '^2.0.0-beta.0',
+	},
+	joi: {
+		name: 'joi',
+		scope: 'regular',
+		version: '^17.13.3',
+	},
+	'@exodus/schemasafe': {
+		name: '@exodus/schemasafe',
+		scope: 'regular',
+		version: '^1.3.0',
+	},
+	superstruct: {
+		name: 'superstruct',
+		scope: 'regular',
+		version: '^2.0.2',
+	},
+	'@sinclair/typebox': {
+		name: '@sinclair/typebox',
+		scope: 'regular',
+		version: '^0.32.34',
+	},
+	valibot: {
+		name: 'valibot',
+		scope: 'regular',
+		version: '^0.36.0',
+	},
+	'@vinejs/vine': {
+		name: '@vinejs/vine',
+		scope: 'regular',
+		version: '^2.1.0',
+	},
+	yup: {
+		name: 'yup',
+		scope: 'regular',
+		version: '^1.4.0',
+	},
 	'tailwind-variants': {
 		name: 'tailwind-variants',
 		scope: 'regular',


### PR DESCRIPTION
- Adds packages to package array
- Adds options under sveltekit-superforms