### PR TITLE
fix: Remove `.ts` postfix from import alias

### DIFF
--- a/.changeset/hungry-badgers-jump.md
+++ b/.changeset/hungry-badgers-jump.md
@@ -1,0 +1,5 @@
+---
+'@iedan/create': patch
+---
+
+fix: Removes `.ts` postfix from the shadcn-svelte import alias to fix issue with paths.

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,7 +73,7 @@ const main = async () => {
 						run: async (result, { state, dir, error }) => {
 							await $({
 								cwd: dir,
-							})`npx shadcn-svelte@latest init --no-deps --style ${state.shadcnSvelteConfig.style} --base-color ${result.toLowerCase()} --css src/app.css --tailwind-config tailwind.config.ts --components-alias $lib/components --utils-alias $lib/utils.ts`.catch(
+							})`npx shadcn-svelte@latest init --no-deps --style ${state.shadcnSvelteConfig.style} --base-color ${result.toLowerCase()} --css src/app.css --tailwind-config tailwind.config.ts --components-alias $lib/components --utils-alias $lib/utils`.catch(
 								(err) => error(err)
 							);
 


### PR DESCRIPTION
This shouldn't have taken so long to notice but here we are.